### PR TITLE
Cherry-pick: Add Cmd+F search to LogListGrid (from upstream #3338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,42 @@
 ## Unreleased
 
+- Anthropic: Handle updated Anthropic compaction not supported error message.
+- OpenAI: Use fallback for token counting and compaction endpoints when running in environments (e.g. AzureAI) where they are not supported.
+- Serialization: Remove dependency on `frozendict` as fallback; update jsonpath-ng dependency.
+- Task view: Extract and print `<summary>` from `<details>` tags in tool views.
+- Inspect View: Add support for find in log list.
+- Inspect View: Fix regression displaying running samples when switching samples.
+
+## 0.3.185 (01 March 2026)
+
+- Anthropic: Use `text_editor_20250728` for all Claude 4.x models per Anthropic docs.
+- Events: Add `agent_span_id` property to tool events for associating them with their associated agent.
+
+## 0.3.184 (28 February 2026)
+
+- Model API: By default, only log raw model api request/response when an error occurs. Override to log all model api calls with `--log-model-api`.
+- Model API: Truncate the model request to a maximum of 200 lines when printing to the console after an error.
 - Model API: Add SageMaker provider for invoking models hosted on AWS SageMaker endpoints.
 - Model API: Normalize handling of cached tokens in `ModelUsage` (input tokens now excludes cached tokens whereas previously it included them for some providers).
 - Model API: Track model usage by model role in addition to globally.
+- OpenAI: Capture system and user messages in compaction responses.
 - OpenAI: Warn user when reasoning options are passed to non-reasoning model.
 - OpenAI: Pass through `phase` for gpt-5.3-codex models.
 - OpenAI Compatible: Re-create closed httpx client after disconnect.
 - Anthropic: Support ANTHROPIC_AUTH_TOKEN for OAuth Bearer authentication.
+- Anthropic: Enable `computer_20251124` tool version (with zoom) for Claude Sonnet 4.6.
 - vLLM: Support for LoRA (Low-Rank Adaptation) via `--enable-lora` server option and LoRA-tuned server startup logic.
+- Tools: Enable parameter placeholders in tool views.
 - OpenRouter: Improved capture of reasoning summaries for Gemini models.
+- Scoring: Add `math()` scorer which handles comparing mathematical expressions.
+- ReAct Agent: Break out of `react()` agent loop if the model refuses three times without choosing to call the `submit()` tool. 
 - Agent Bridge: Only require `openai` package when bridging the openai completions or reaponses API.
 - Sandbox Tools: Increase server startup timeout from 20 seconds to 120 seconds.
 - Timelines: Improve agent detection logic in `timeline_build()`.
 - Performance: Share a single `AsyncFilesystem` via ContextVar within each async context, eliminating redundant S3 client creation and connection pool fragmentation.
 - Inspect View: Improve virtualized find in transcript by matching event titles as well as contents.
 - Testing: Migrate async tests from pytest-asyncio to anyio, enabling dual-backend (asyncio/trio) test execution via `--runtrio` flag.
+- Testing: Run `--runtrio` as trio-only in a separate process to prevent cross-backend global state contamination; convert batch tests from asyncio to anyio.
 - Bugfix: Strip surrounding quotes from S3 ETag in `.eval` header-only reads so it is consistent with full reads.
 
 ## 0.3.183 (24 February 2026)
@@ -28,6 +50,7 @@
 
 - AzureAI: Pass `max_completion_tokens` to gpt-5 and o-series models.
 - Events: Add timeline functions for providing additional structure for event viewing and traversal.
+- Bugfix: Fix Inspect View showing stale sample data when rapidly switching between samples.
 
 ## 0.3.181 (23 February 2026)
 
@@ -93,6 +116,7 @@
 - Inspect View: Improve transcript display appearance in VSCode.
 - Inspect View: Improve log events display in transcripts.
 - Bugfix: Fix off-by-one in `_read_all_summaries` that skipped the last sample summary.
+- Inspect View: Fix stale state read in logsSlice after syncLogs.
 
 ## 0.3.177 (10 February 2026)
 

--- a/src/inspect_ai/_view/www/dist/assets/index.css
+++ b/src/inspect_ai/_view/www/dist/assets/index.css
@@ -16680,6 +16680,59 @@ button._segment_mhb7y_9 {
   min-width: 0;
   flex: 1;
 }
+.findBand {
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin-right: 20%;
+  z-index: 1060;
+  color: var(--inspect-find-foreground);
+  background-color: var(--inspect-find-background);
+  font-size: 0.9rem;
+  display: grid;
+  grid-template-columns: auto auto auto auto auto;
+  column-gap: 0.2em;
+  padding: 0.2rem;
+  border-bottom: solid 1px var(--bs-light-border-subtle);
+  border-left: solid 1px var(--bs-light-border-subtle);
+  border-right: solid 1px var(--bs-light-border-subtle);
+  box-shadow: var(--bs-box-shadow);
+}
+
+.findBand input {
+  height: 2em;
+  font-size: 0.9em;
+  margin: 0.1rem;
+  outline: none;
+  border: solid 1px var(--inspect-input-border);
+  color: var(--inspect-input-foreground);
+  background: var(--inspect-input-background);
+}
+
+#inspect-find-no-results {
+  font-size: 0.9em;
+  opacity: 0;
+  margin-top: auto;
+  margin-bottom: auto;
+  margin-right: 0.5em;
+}
+
+.findBand .btn.next,
+.findBand .btn.prev {
+  padding: 0;
+  border: none;
+  background: none;
+  font-size: var(--inspect-fond-size-larger);
+}
+
+.findBand .btn.close {
+  padding: 0;
+  border: none;
+  background: none;
+  font-size: var(--inspect-font-size-title-secondary);
+  margin-top: -0.1rem;
+  margin-bottom: -0.1rem;
+}
 ._footer_14uod_1 {
   border-top: solid var(--bs-light-border-subtle) 1px;
   background: var(--bs-light-bg-subtle);
@@ -16746,55 +16799,6 @@ button._segment_mhb7y_9 {
   overflow: hidden;
   height: 100%;
   min-height: 0;
-}
-.findBand {
-  position: absolute;
-  top: 0;
-  right: 0;
-  margin-right: 20%;
-  z-index: 1060;
-  color: var(--inspect-find-foreground);
-  background-color: var(--inspect-find-background);
-  font-size: 0.9rem;
-  display: grid;
-  grid-template-columns: auto auto auto auto auto;
-  column-gap: 0.2em;
-  padding: 0.2rem;
-  border-bottom: solid 1px var(--bs-light-border-subtle);
-  border-left: solid 1px var(--bs-light-border-subtle);
-  border-right: solid 1px var(--bs-light-border-subtle);
-  box-shadow: var(--bs-box-shadow);
-}
-
-.findBand input {
-  height: 2em;
-  font-size: 0.9em;
-  margin: 0.1rem;
-  outline: none;
-  border: solid 1px var(--inspect-input-border);
-  color: var(--inspect-input-foreground);
-  background: var(--inspect-input-background);
-}
-
-#inspect-find-no-results {
-  font-size: 0.9em;
-  opacity: 0;
-  margin-top: auto;
-  margin-bottom: auto;
-  margin-right: 0.5em;
-}
-
-.findBand .btn.next,
-.findBand .btn.prev {
-  padding: 0;
-  font-size: var(--inspect-fond-size-larger);
-}
-
-.findBand .btn.close {
-  padding: 0;
-  font-size: var(--inspect-font-size-title-secondary);
-  margin-top: -0.1rem;
-  margin-bottom: -0.1rem;
 }
 ._tabs_1rv6h_1 {
   align-items: center;

--- a/src/inspect_ai/_view/www/src/app/log-list/grid/LogListGrid.tsx
+++ b/src/inspect_ai/_view/www/src/app/log-list/grid/LogListGrid.tsx
@@ -7,9 +7,19 @@ import type {
 import { themeBalham } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import clsx from "clsx";
-import { FC, RefObject, useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  FC,
+  KeyboardEvent as ReactKeyboardEvent,
+  RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useNavigate } from "react-router-dom";
 
+import { FindBandUI } from "../../../components/FindBandUI";
 import { useLogs, useLogsListing } from "../../../state/hooks";
 import { useStore } from "../../../state/store";
 import "../../shared/agGrid";
@@ -51,6 +61,21 @@ export const LogListGrid: FC<LogListGridProps> = ({
   const internalGridRef = useRef<AgGridReact<LogListRow>>(null);
   const gridRef = externalGridRef ?? internalGridRef;
   const gridContainerRef = useRef<HTMLDivElement>(null);
+
+  // Find functionality state - store row IDs instead of IRowNode references to avoid memory leaks
+  const [showFind, setShowFind] = useState(false);
+  const [findTerm, setFindTerm] = useState("");
+  const [matchIds, setMatchIds] = useState<string[]>([]);
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+  const findInputRef = useRef<HTMLInputElement>(null);
+
+  // Helper to close find bar and reset state
+  const closeFind = useCallback(() => {
+    setShowFind(false);
+    setFindTerm("");
+    setMatchIds([]);
+    setCurrentMatchIndex(0);
+  }, []);
 
   const logFiles = useMemo(() => {
     return items
@@ -123,6 +148,12 @@ export const LogListGrid: FC<LogListGridProps> = ({
           }
         }
       }
+
+      // Pre-compute searchable text for fast Cmd+F search
+      row.searchText = [row.name, row.task, row.model, row.id]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
 
       return row;
     });
@@ -231,8 +262,111 @@ export const LogListGrid: FC<LogListGridProps> = ({
     resizeGridColumns();
   }, [columns, resizeGridColumns]);
 
+  // Find functionality - uses pre-computed searchText for O(1) lookup per row
+  const performSearch = useCallback(
+    (term: string) => {
+      const api = gridRef.current?.api;
+      if (!api || !term) {
+        setMatchIds([]);
+        setCurrentMatchIndex(0);
+        return;
+      }
+      const lowerTerm = term.toLowerCase();
+      const foundIds: string[] = [];
+      api.forEachNode((node) => {
+        const rowData = node.data;
+        if (!rowData?.searchText) return;
+        if (rowData.searchText.includes(lowerTerm)) {
+          foundIds.push(rowData.id);
+        }
+      });
+      setMatchIds(foundIds);
+      setCurrentMatchIndex(0);
+      if (foundIds.length > 0) {
+        const firstNode = api.getRowNode(foundIds[0]);
+        if (firstNode) {
+          api.deselectAll();
+          api.ensureNodeVisible(firstNode, "middle");
+          firstNode.setSelected(true, true);
+        }
+      }
+    },
+    [gridRef],
+  );
+
+  const goToMatch = useCallback(
+    (index: number) => {
+      if (matchIds.length === 0) return;
+      const idx =
+        ((index % matchIds.length) + matchIds.length) % matchIds.length;
+      setCurrentMatchIndex(idx);
+      const api = gridRef.current?.api;
+      if (!api) return;
+      const node = api.getRowNode(matchIds[idx]);
+      if (node) {
+        api.deselectAll();
+        api.ensureNodeVisible(node, "middle");
+        node.setSelected(true, true);
+      }
+    },
+    [matchIds, gridRef],
+  );
+
+  const handleInputKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Escape") {
+        closeFind();
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        goToMatch(currentMatchIndex + (e.shiftKey ? -1 : 1));
+      }
+    },
+    [goToMatch, currentMatchIndex, closeFind],
+  );
+
+  useEffect(() => {
+    const handleFindKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "f") {
+        e.preventDefault();
+        e.stopPropagation();
+        setShowFind(true);
+        setTimeout(() => findInputRef.current?.focus(), 100);
+      }
+      if (e.key === "Escape" && showFind) {
+        closeFind();
+      }
+    };
+    document.addEventListener("keydown", handleFindKeyDown, true);
+    return () =>
+      document.removeEventListener("keydown", handleFindKeyDown, true);
+  }, [closeFind, showFind]);
+
+  useEffect(() => {
+    if (findTerm) {
+      performSearch(findTerm);
+    } else {
+      setMatchIds([]);
+      setCurrentMatchIndex(0);
+    }
+  }, [findTerm, performSearch]);
+
   return (
     <div className={clsx(styles.gridWrapper)}>
+      {showFind && (
+        <FindBandUI
+          inputRef={findInputRef}
+          value={findTerm}
+          onChange={() => setFindTerm(findInputRef.current?.value ?? "")}
+          onKeyDown={handleInputKeyDown}
+          onClose={closeFind}
+          onPrevious={() => goToMatch(currentMatchIndex - 1)}
+          onNext={() => goToMatch(currentMatchIndex + 1)}
+          disableNav={matchIds.length === 0}
+          noResults={!!findTerm && matchIds.length === 0}
+          matchCount={findTerm ? matchIds.length : undefined}
+          matchIndex={findTerm ? currentMatchIndex : undefined}
+        />
+      )}
       <div ref={gridContainerRef} className={styles.gridContainer} tabIndex={0}>
         <AgGridReact<LogListRow>
           ref={gridRef}

--- a/src/inspect_ai/_view/www/src/app/log-list/grid/columns/types.ts
+++ b/src/inspect_ai/_view/www/src/app/log-list/grid/columns/types.ts
@@ -13,5 +13,6 @@ export interface LogListRow {
   completedAt?: string;
   itemCount?: number;
   log?: LogHandle;
+  searchText?: string; // Pre-computed searchable text for fast Cmd+F search
   [key: string]: any; // For dynamic score columns
 }

--- a/src/inspect_ai/_view/www/src/components/FindBand.css
+++ b/src/inspect_ai/_view/www/src/components/FindBand.css
@@ -38,11 +38,15 @@
 .findBand .btn.next,
 .findBand .btn.prev {
   padding: 0;
+  border: none;
+  background: none;
   font-size: var(--inspect-fond-size-larger);
 }
 
 .findBand .btn.close {
   padding: 0;
+  border: none;
+  background: none;
   font-size: var(--inspect-font-size-title-secondary);
   margin-top: -0.1rem;
   margin-bottom: -0.1rem;

--- a/src/inspect_ai/_view/www/src/components/FindBand.tsx
+++ b/src/inspect_ai/_view/www/src/components/FindBand.tsx
@@ -1,4 +1,3 @@
-import clsx from "clsx";
 import {
   FC,
   KeyboardEvent,
@@ -6,13 +5,13 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from "react";
-import { ApplicationIcons } from "../app/appearance/icons";
 import { useStore } from "../state/store";
 import { findScrollableParent, scrollRangeToCenter } from "../utils/dom";
 import { debounce } from "../utils/sync";
 import { useExtendedFind } from "./ExtendedFindContext";
-import "./FindBand.css";
+import { FindBandUI } from "./FindBandUI";
 
 interface FindBandProps {}
 
@@ -27,7 +26,7 @@ const findConfig = {
 export const FindBand: FC<FindBandProps> = () => {
   const searchBoxRef = useRef<HTMLInputElement>(null);
   const storeHideFind = useStore((state) => state.appActions.hideFind);
-  const { extendedFindTerm } = useExtendedFind();
+  const { extendedFindTerm, countAllMatches } = useExtendedFind();
   const lastFoundItem = useRef<{
     text: string;
     offset: number;
@@ -35,11 +34,13 @@ export const FindBand: FC<FindBandProps> = () => {
   } | null>(null);
   const currentSearchTerm = useRef<string>("");
   const needsCursorRestoreRef = useRef<boolean>(false);
-  const lastNoResultTerm = useRef<string>("");
-  const lastNoResultDirection = useRef<boolean | null>(null);
   const scrollTimeoutRef = useRef<number | null>(null);
   const focusTimeoutRef = useRef<number | null>(null);
   const searchIdRef = useRef(0);
+  const cachedCount = useRef<{ term: string; count: number }>({
+    term: "",
+    count: 0,
+  });
   const mutatedPanelsRef = useRef<
     Map<
       HTMLElement,
@@ -51,6 +52,9 @@ export const FindBand: FC<FindBandProps> = () => {
       }
     >
   >(new Map());
+
+  const [matchCount, setMatchCount] = useState<number | null>(null);
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
 
   const getParentExpandablePanel = useCallback(
     (selection: Selection): HTMLElement | undefined => {
@@ -71,87 +75,59 @@ export const FindBand: FC<FindBandProps> = () => {
 
   const handleSearch = useCallback(
     async (back = false) => {
-      // Track this search to handle race conditions
       const thisSearchId = ++searchIdRef.current;
 
-      // The search term
       const searchTerm = searchBoxRef.current?.value ?? "";
       if (!searchTerm) {
+        setMatchCount(null);
+        setCurrentMatchIndex(0);
         return;
       }
 
-      // Reset last found item if search term changed
       if (currentSearchTerm.current !== searchTerm) {
         lastFoundItem.current = null;
         currentSearchTerm.current = searchTerm;
+        setCurrentMatchIndex(0);
       }
 
-      const noResultEl = document.getElementById("inspect-find-no-results");
+      let total: number;
+      if (cachedCount.current.term === searchTerm) {
+        total = cachedCount.current.count;
+      } else {
+        total = countAllMatches(searchTerm);
+        cachedCount.current = { term: searchTerm, count: total };
+      }
+      setMatchCount(total);
 
-      // Skip search if we already know this term has no results in this direction
-      if (
-        lastNoResultTerm.current &&
-        searchTerm.startsWith(lastNoResultTerm.current) &&
-        lastNoResultDirection.current === back
-      ) {
-        if (noResultEl) {
-          noResultEl.style.opacity = "1";
-          noResultEl.setAttribute("aria-hidden", "false");
-        }
+      if (total === 0) {
+        setCurrentMatchIndex(0);
         return;
       }
 
-      // Clear no-result cache if search term changed or direction changed
-      if (
-        lastNoResultTerm.current &&
-        (!searchTerm.startsWith(lastNoResultTerm.current) ||
-          lastNoResultDirection.current !== back)
-      ) {
-        lastNoResultTerm.current = "";
-        lastNoResultDirection.current = null;
-      }
-
-      // Capture the curently focused element so we can restore focus later
       const focusedElement = document.activeElement as HTMLElement;
 
-      // Save current selection before search (window.find may disturb it)
       const selection = window.getSelection();
       let savedRange: Range | null = null;
       if (selection && selection.rangeCount > 0) {
         savedRange = selection.getRangeAt(0).cloneRange();
       }
 
-      // Save scroll position before search (window.find may scroll during search)
       const savedScrollParent = savedRange
         ? findScrollableParent(savedRange.startContainer.parentElement)
         : null;
       const savedScrollTop = savedScrollParent?.scrollTop ?? 0;
 
-      // Find the term in the DOM
-      let result = await findExtendedInDOM(
+      const result = await findExtendedInDOM(
         searchTerm,
         back,
         lastFoundItem.current,
         extendedFindTerm,
       );
 
-      if (!noResultEl) {
-        return;
-      }
-
-      // If a newer search has started, discard this result to avoid race conditions
       if (searchIdRef.current !== thisSearchId) {
         return;
       }
 
-      // Show "No results" if neither current DOM nor virtual search found anything
-      noResultEl.style.opacity = result ? "0" : "1";
-      noResultEl.setAttribute("aria-hidden", result ? "true" : "false");
-
-      lastNoResultTerm.current = result ? "" : searchTerm;
-      lastNoResultDirection.current = result ? null : back;
-
-      // If no result found, restore the previous selection so we stay on current match
       if (!result && savedRange) {
         const sel = window.getSelection();
         if (sel) {
@@ -166,20 +142,29 @@ export const FindBand: FC<FindBandProps> = () => {
       if (result) {
         const selection = window.getSelection();
         if (selection && selection.rangeCount > 0) {
-          // Remember this item for next time
           const range = selection.getRangeAt(0);
           const parentElement =
             range.startContainer.parentElement ||
             (range.commonAncestorContainer as Element);
+          const isNewMatch = !isLastFoundItem(range, lastFoundItem.current);
           lastFoundItem.current = {
             text: range.toString(),
             offset: range.startOffset,
             parentElement,
           };
 
+          if (isNewMatch) {
+            setCurrentMatchIndex((prev) => {
+              if (back) {
+                return prev <= 1 ? total : prev - 1;
+              } else {
+                return prev >= total ? 1 : prev + 1;
+              }
+            });
+          }
+
           const parentPanel = getParentExpandablePanel(selection);
           if (parentPanel) {
-            // Save original styles if not already tracked
             if (!mutatedPanelsRef.current.has(parentPanel)) {
               mutatedPanelsRef.current.set(parentPanel, {
                 display: parentPanel.style.display,
@@ -194,7 +179,6 @@ export const FindBand: FC<FindBandProps> = () => {
             parentPanel.style.webkitBoxOrient = "";
           }
 
-          // Scroll the selection into view (with a small delay for DOM updates)
           if (scrollTimeoutRef.current !== null) {
             window.clearTimeout(scrollTimeoutRef.current);
           }
@@ -206,7 +190,7 @@ export const FindBand: FC<FindBandProps> = () => {
 
       focusedElement?.focus();
     },
-    [getParentExpandablePanel, extendedFindTerm],
+    [getParentExpandablePanel, extendedFindTerm, countAllMatches],
   );
 
   useEffect(() => {
@@ -215,7 +199,6 @@ export const FindBand: FC<FindBandProps> = () => {
       searchBoxRef.current?.select();
     }, 10);
 
-    // Capture ref values for cleanup
     const mutatedPanels = mutatedPanelsRef.current;
     const scrollTimeout = scrollTimeoutRef.current;
     const focusTimeout = focusTimeoutRef.current;
@@ -273,7 +256,6 @@ export const FindBand: FC<FindBandProps> = () => {
     }
   }, []);
 
-  // Debounced auto-search as you type
   const debouncedSearch = useMemo(
     () =>
       debounce(async () => {
@@ -290,8 +272,6 @@ export const FindBand: FC<FindBandProps> = () => {
   }, [debouncedSearch]);
 
   const handleBeforeInput = useCallback(() => {
-    // Only restore cursor if no text is selected
-    // This preserves native browser behavior (typing replaces selected text)
     const input = searchBoxRef.current;
     if (input) {
       const hasSelection = input.selectionStart !== input.selectionEnd;
@@ -328,18 +308,14 @@ export const FindBand: FC<FindBandProps> = () => {
         return;
       }
 
-      // Skip if modifier keys are held (except for handled shortcuts above)
       if (e.ctrlKey || e.metaKey || e.altKey) return;
 
-      // Auto-focus input when typing printable characters or backspace/delete
       if (e.key.length !== 1 && e.key !== "Backspace" && e.key !== "Delete")
         return;
 
       const input = searchBoxRef.current;
       if (!input) return;
 
-      // Only restore cursor if no text is selected
-      // This preserves native browser behavior (typing replaces selected text)
       const hasSelection = input.selectionStart !== input.selectionEnd;
       if (!hasSelection) {
         restoreCursor();
@@ -350,7 +326,6 @@ export const FindBand: FC<FindBandProps> = () => {
       }
     };
 
-    // Use capture phase to intercept browser's native find dialog
     document.addEventListener("keydown", handleGlobalKeyDown, true);
     return () => {
       document.removeEventListener("keydown", handleGlobalKeyDown, true);
@@ -358,45 +333,49 @@ export const FindBand: FC<FindBandProps> = () => {
   }, [handleSearch, restoreCursor]);
 
   return (
-    <div data-unsearchable="true" className={clsx("findBand")}>
-      <input
-        type="text"
-        ref={searchBoxRef}
-        placeholder="Find"
-        onKeyDown={handleKeyDown}
-        onBeforeInput={handleBeforeInput}
-        onChange={handleInputChange}
-      />
-      <span id="inspect-find-no-results" aria-hidden="true">
-        No results
-      </span>
-      <button
-        type="button"
-        title="Previous match"
-        className="btn next"
-        onClick={findPrevious}
-      >
-        <i className={ApplicationIcons.arrows.up} />
-      </button>
-      <button
-        type="button"
-        title="Next match"
-        className="btn prev"
-        onClick={findNext}
-      >
-        <i className={ApplicationIcons.arrows.down} />
-      </button>
-      <button
-        type="button"
-        title="Close"
-        className="btn close"
-        onClick={storeHideFind}
-      >
-        <i className={ApplicationIcons.close} />
-      </button>
-    </div>
+    <FindBandUI
+      inputRef={searchBoxRef}
+      onClose={storeHideFind}
+      onNext={findNext}
+      onPrevious={findPrevious}
+      onKeyDown={handleKeyDown}
+      onBeforeInput={handleBeforeInput}
+      onChange={handleInputChange}
+      noResults={matchCount !== null && matchCount === 0}
+      matchCount={matchCount ?? undefined}
+      matchIndex={
+        matchCount !== null && matchCount > 0
+          ? currentMatchIndex - 1
+          : undefined
+      }
+    />
   );
 };
+function windowFind(searchTerm: string, back: boolean): boolean {
+  // @ts-expect-error: `Window.find` is non-standard
+  return window.find(
+    searchTerm,
+    findConfig.caseSensitive,
+    back,
+    findConfig.wrapAround,
+    findConfig.wholeWord,
+    findConfig.searchInFrames,
+    findConfig.showDialog,
+  ) as boolean;
+}
+
+function positionSelectionForWrap(back: boolean): void {
+  if (!back) return;
+  const sel = window.getSelection();
+  if (sel) {
+    const range = document.createRange();
+    range.selectNodeContents(document.body);
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  }
+}
+
 async function findExtendedInDOM(
   searchTerm: string,
   back: boolean,
@@ -411,50 +390,68 @@ async function findExtendedInDOM(
   ) => Promise<boolean>,
 ) {
   let result = false;
-  let attempts = 0;
   let hasTriedExtendedSearch = false;
+  let extendedSearchSucceeded = false;
   const maxAttempts = 25;
 
-  do {
-    // @ts-expect-error: `Window.find` is non-standard
-    result = window.find(
-      searchTerm,
-      findConfig.caseSensitive,
-      back,
-      findConfig.wrapAround,
-      findConfig.wholeWord,
-      findConfig.searchInFrames,
-      findConfig.showDialog,
-    );
+  for (let attempts = 0; attempts < maxAttempts; attempts++) {
+    result = windowFind(searchTerm, back);
 
     if (result) {
-      // We have a result, check whether it is valid (not in unsearchable
-      // element and not the same as last). If is isn't valid, ignore it
-      // and continue the loop to find the next match.
       const selection = window.getSelection();
       if (selection && selection.rangeCount > 0) {
         const range = selection.getRangeAt(0);
-
-        // We mark certain elements as unsearchable
         const isUnsearchable = inUnsearchableElement(range);
-
-        // Also check if it's the same item as last time
         const isSameAsLast = isLastFoundItem(range, lastFoundItem);
 
-        // If this is a valid match (not unsearchable and not same as last), we're done
         if (!isUnsearchable && !isSameAsLast) {
           break;
         }
 
-        // If we found the same match as last time, there are no new results
         if (isSameAsLast) {
-          return false;
+          if (!hasTriedExtendedSearch) {
+            hasTriedExtendedSearch = true;
+            window.getSelection()?.removeAllRanges();
+
+            const foundInVirtual = await extendedFindTerm(
+              searchTerm,
+              back ? "backward" : "forward",
+            );
+
+            if (foundInVirtual) {
+              extendedSearchSucceeded = true;
+              continue;
+            }
+          }
+
+          if (extendedSearchSucceeded) {
+            // Extended search scrolled to new content but old match is still in DOM.
+            // Collapse past it so windowFind advances to the new match.
+            const sel = window.getSelection();
+            if (sel?.rangeCount) {
+              sel.getRangeAt(0).collapse(!back);
+            }
+          } else {
+            window.getSelection()?.removeAllRanges();
+            positionSelectionForWrap(back);
+          }
+
+          result = windowFind(searchTerm, back);
+          if (result) {
+            const sel = window.getSelection();
+            if (sel && sel.rangeCount > 0) {
+              const r = sel.getRangeAt(0);
+              if (inUnsearchableElement(r)) {
+                continue;
+              }
+            }
+          }
+          break;
         }
-        // Otherwise continue the loop to find the next match (skip unsearchable)
       }
     } else if (!hasTriedExtendedSearch) {
-      // No result in current DOM and haven't tried extended search yet
       hasTriedExtendedSearch = true;
+      window.getSelection()?.removeAllRanges();
 
       const foundInVirtual = await extendedFindTerm(
         searchTerm,
@@ -462,19 +459,35 @@ async function findExtendedInDOM(
       );
 
       if (foundInVirtual) {
-        // Found in virtual list (which will have scrolled the item into view),
-        // so try finding again in the DOM
-      } else {
-        // Extended search failed, no more options
-        break;
+        extendedSearchSucceeded = true;
+        continue;
       }
+
+      positionSelectionForWrap(back);
+      result = windowFind(searchTerm, back);
+      if (result) {
+        const sel = window.getSelection();
+        if (sel && sel.rangeCount > 0) {
+          const r = sel.getRangeAt(0);
+          if (inUnsearchableElement(r)) {
+            continue;
+          }
+        }
+      }
+      break;
     } else {
-      // No result and already tried extended search
       break;
     }
+  }
 
-    attempts++;
-  } while (attempts < maxAttempts);
+  if (result) {
+    const sel = window.getSelection();
+    if (sel?.rangeCount && inUnsearchableElement(sel.getRangeAt(0))) {
+      sel.removeAllRanges();
+      result = false;
+    }
+  }
+
   return result;
 }
 

--- a/src/inspect_ai/_view/www/src/components/FindBandUI.tsx
+++ b/src/inspect_ai/_view/www/src/components/FindBandUI.tsx
@@ -1,0 +1,97 @@
+import clsx from "clsx";
+import React, { FC, KeyboardEvent, RefObject, useRef } from "react";
+import { ApplicationIcons } from "../app/appearance/icons";
+import "./FindBand.css";
+
+interface FindBandUIProps {
+  onClose: () => void;
+  onNext: () => void;
+  onPrevious: () => void;
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
+  onChange?: () => void;
+  onBeforeInput?: () => void;
+  value?: string;
+  matchCount?: number;
+  matchIndex?: number;
+  noResults?: boolean;
+  disableNav?: boolean;
+  inputRef?: RefObject<HTMLInputElement | null>;
+}
+
+export const FindBandUI: FC<FindBandUIProps> = ({
+  onClose,
+  onNext,
+  onPrevious,
+  onKeyDown,
+  onChange,
+  onBeforeInput,
+  value,
+  matchCount,
+  matchIndex,
+  noResults = false,
+  disableNav,
+  inputRef: externalRef,
+}) => {
+  const internalRef = useRef<HTMLInputElement>(null);
+  const inputRef = externalRef ?? internalRef;
+
+  // Build input props — only include `value` when controlled
+  const inputProps: React.InputHTMLAttributes<HTMLInputElement> = {
+    type: "text",
+    placeholder: "Find",
+    onKeyDown,
+    onBeforeInput,
+    onChange,
+  };
+  if (value !== undefined) {
+    inputProps.value = value;
+  }
+
+  const hasCount = matchCount !== undefined && matchIndex !== undefined;
+  const showStatus = noResults || (hasCount && matchCount > 0);
+  const statusText =
+    hasCount && matchCount > 0
+      ? `${matchIndex + 1} of ${matchCount}`
+      : "No results";
+
+  return (
+    <div data-unsearchable="true" className={clsx("findBand")}>
+      <input ref={inputRef} {...inputProps} />
+      <span
+        className={clsx(
+          "findBand-match-count",
+          noResults && matchCount === 0 && "findBand-no-results",
+        )}
+        style={{ visibility: showStatus ? "visible" : "hidden" }}
+      >
+        {statusText}
+      </span>
+      <button
+        type="button"
+        title="Previous match"
+        className="btn prev"
+        onClick={onPrevious}
+        disabled={disableNav}
+      >
+        <i className={ApplicationIcons.arrows.up} />
+      </button>
+      <button
+        type="button"
+        title="Next match"
+        className="btn next"
+        onClick={onNext}
+        disabled={disableNav}
+      >
+        <i className={ApplicationIcons.arrows.down} />
+      </button>
+      <button
+        type="button"
+        title="Close"
+        className="btn close"
+        onClick={onClose}
+      >
+        <i className={ApplicationIcons.close} />
+      </button>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Cherry-picks the Cmd+F search feature from upstream PR [UKGovernmentBEIS/inspect_ai#3338](https://github.com/UKGovernmentBEIS/inspect_ai/pull/3338).

**Note:** The dist files have been rebuilt from METR fork source to ensure compatibility.

## Changes

- Adds custom find bar to LogListGrid (tasks list)
- Intercepts Cmd+F / Ctrl+F for AG Grid search
- Extracts shared `FindBandUI` component (upstream refactor)
- Pre-computes searchable text for O(1) lookup
- Stores row IDs instead of IRowNode references (memory leak fix)

## Test Plan

1. Open Inspect View with 20+ eval files
2. Press Cmd+F - find bar should appear
3. Search for a task/model name
4. Navigate with Enter/Shift+Enter or ↑/↓ buttons
5. Press Escape to close