### PR TITLE
[PLT-490] Add Cmd+F search to LogListGrid (tasks list)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Performance: Share a single `AsyncFilesystem` via ContextVar within each async context, eliminating redundant S3 client creation and connection pool fragmentation.
 - Inspect View: Improve virtualized find in transcript by matching event titles as well as contents.
 - Inspect View: Add support for find in log list (Cmd+F in tasks grid).
+- Inspect View: Improve transcript event styling.
 - Testing: Migrate async tests from pytest-asyncio to anyio, enabling dual-backend (asyncio/trio) test execution via `--runtrio` flag.
 - Bugfix: Strip surrounding quotes from S3 ETag in `.eval` header-only reads so it is consistent with full reads.
 - Inspect View: Presigned URL support for S3 log files, enabling direct browser-to-S3 byte-range fetches with parallel chunk downloads and a determinate progress bar for large samples.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Inspect View: Improve virtualized find in transcript by matching event titles as well as contents.
 - Inspect View: Add support for find in log list (Cmd+F in tasks grid).
 - Inspect View: Improve transcript event styling.
+- Inspect View: Fix scroll cutoff in virtual list sample tabs.
 - Testing: Migrate async tests from pytest-asyncio to anyio, enabling dual-backend (asyncio/trio) test execution via `--runtrio` flag.
 - Bugfix: Strip surrounding quotes from S3 ETag in `.eval` header-only reads so it is consistent with full reads.
 - Inspect View: Presigned URL support for S3 log files, enabling direct browser-to-S3 byte-range fetches with parallel chunk downloads and a determinate progress bar for large samples.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Timelines: Improve agent detection logic in `timeline_build()`.
 - Performance: Share a single `AsyncFilesystem` via ContextVar within each async context, eliminating redundant S3 client creation and connection pool fragmentation.
 - Inspect View: Improve virtualized find in transcript by matching event titles as well as contents.
+- Inspect View: Add support for find in log list (Cmd+F in tasks grid).
 - Testing: Migrate async tests from pytest-asyncio to anyio, enabling dual-backend (asyncio/trio) test execution via `--runtrio` flag.
 - Bugfix: Strip surrounding quotes from S3 ETag in `.eval` header-only reads so it is consistent with full reads.
 - Inspect View: Presigned URL support for S3 log files, enabling direct browser-to-S3 byte-range fetches with parallel chunk downloads and a determinate progress bar for large samples.

--- a/src/inspect_ai/_view/www/dist/assets/index.css
+++ b/src/inspect_ai/_view/www/dist/assets/index.css
@@ -16321,7 +16321,7 @@ a._citationLink_1ggvf_9:hover {
 ._viewerOptions_1bbut_7 {
   color: var(--bs-body-color);
 }
-._wrapper_1tajk_1 {
+._wrapper_44dmw_1 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -16332,7 +16332,7 @@ a._citationLink_1ggvf_9:hover {
   text-align: center;
 }
 
-._container_1tajk_12 {
+._container_44dmw_12 {
   width: 100%;
   height: 1px;
   background-color: transparent;
@@ -16341,17 +16341,26 @@ a._citationLink_1ggvf_9:hover {
   z-index: 1200;
 }
 
-._animate_1tajk_21 {
+._animate_44dmw_21 {
   width: 5%;
   height: 1px;
-  animation: _leftToRight_1tajk_1 2s linear infinite;
+  animation: _leftToRight_44dmw_1 2s linear infinite;
   background-color: #3b82f6;
   position: absolute;
   left: 0;
   top: 0;
 }
 
-@keyframes _leftToRight_1tajk_1 {
+._determinate_44dmw_31 {
+  height: 1px;
+  background-color: #3b82f6;
+  position: absolute;
+  left: 0;
+  top: 0;
+  transition: width 150ms ease-out;
+}
+
+@keyframes _leftToRight_44dmw_1 {
   0% {
     transform: translateX(-100%);
   }

--- a/src/inspect_ai/_view/www/dist/assets/index.css
+++ b/src/inspect_ai/_view/www/dist/assets/index.css
@@ -16689,6 +16689,66 @@ button._segment_mhb7y_9 {
   min-width: 0;
   flex: 1;
 }
+.findBand {
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin-right: 20%;
+  z-index: 1060;
+  color: var(--inspect-find-foreground);
+  background-color: var(--inspect-find-background);
+  font-size: 0.9rem;
+  display: grid;
+  grid-template-columns: auto auto auto auto auto;
+  column-gap: 0.2em;
+  padding: 0.2rem;
+  border-bottom: solid 1px var(--bs-light-border-subtle);
+  border-left: solid 1px var(--bs-light-border-subtle);
+  border-right: solid 1px var(--bs-light-border-subtle);
+  box-shadow: var(--bs-box-shadow);
+}
+
+.findBand input {
+  height: 2em;
+  font-size: 0.9em;
+  margin: 0.1rem;
+  outline: none;
+  border: solid 1px var(--inspect-input-border);
+  color: var(--inspect-input-foreground);
+  background: var(--inspect-input-background);
+}
+
+.findBand-match-count {
+  font-size: 0.85em;
+  margin-top: auto;
+  margin-bottom: auto;
+  margin-right: 0.5em;
+  white-space: nowrap;
+  color: var(--inspect-find-foreground);
+  opacity: 0.7;
+}
+
+.findBand-no-results {
+  opacity: 1;
+  color: var(--bs-danger, #dc3545);
+}
+
+.findBand .btn.next,
+.findBand .btn.prev {
+  padding: 0;
+  border: none;
+  background: none;
+  font-size: var(--inspect-fond-size-larger);
+}
+
+.findBand .btn.close {
+  padding: 0;
+  border: none;
+  background: none;
+  font-size: var(--inspect-font-size-title-secondary);
+  margin-top: -0.1rem;
+  margin-bottom: -0.1rem;
+}
 ._footer_14uod_1 {
   border-top: solid var(--bs-light-border-subtle) 1px;
   background: var(--bs-light-bg-subtle);
@@ -16755,62 +16815,6 @@ button._segment_mhb7y_9 {
   overflow: hidden;
   height: 100%;
   min-height: 0;
-}
-.findBand {
-  position: absolute;
-  top: 0;
-  right: 0;
-  margin-right: 20%;
-  z-index: 1060;
-  color: var(--inspect-find-foreground);
-  background-color: var(--inspect-find-background);
-  font-size: 0.9rem;
-  display: grid;
-  grid-template-columns: auto auto auto auto auto;
-  column-gap: 0.2em;
-  padding: 0.2rem;
-  border-bottom: solid 1px var(--bs-light-border-subtle);
-  border-left: solid 1px var(--bs-light-border-subtle);
-  border-right: solid 1px var(--bs-light-border-subtle);
-  box-shadow: var(--bs-box-shadow);
-}
-
-.findBand input {
-  height: 2em;
-  font-size: 0.9em;
-  margin: 0.1rem;
-  outline: none;
-  border: solid 1px var(--inspect-input-border);
-  color: var(--inspect-input-foreground);
-  background: var(--inspect-input-background);
-}
-
-.findBand-match-count {
-  font-size: 0.85em;
-  margin-top: auto;
-  margin-bottom: auto;
-  margin-right: 0.5em;
-  white-space: nowrap;
-  color: var(--inspect-find-foreground);
-  opacity: 0.7;
-}
-
-.findBand-no-results {
-  opacity: 1;
-  color: var(--bs-danger, #dc3545);
-}
-
-.findBand .btn.next,
-.findBand .btn.prev {
-  padding: 0;
-  font-size: var(--inspect-fond-size-larger);
-}
-
-.findBand .btn.close {
-  padding: 0;
-  font-size: var(--inspect-font-size-title-secondary);
-  margin-top: -0.1rem;
-  margin-bottom: -0.1rem;
 }
 ._tabs_1rv6h_1 {
   align-items: center;

--- a/src/inspect_ai/_view/www/dist/assets/index.css
+++ b/src/inspect_ai/_view/www/dist/assets/index.css
@@ -16159,25 +16159,27 @@ a._citationLink_1ggvf_9:hover {
 ._toolPanel_1792k_40 {
   display: contents;
 }
-._toolImage_1wvgr_1 {
+._toolImage_h7uyp_1 {
   max-width: 800px;
   border: solid var(--bs-border-color) 1px;
 }
 
-._output_1wvgr_6 {
+._output_h7uyp_6 {
   display: grid;
 }
 
-._textOutput_1wvgr_10 {
+._textOutput_h7uyp_10 {
   padding-left: 2px;
   padding: 0.5em 0.5em 0.5em 0.5em;
   white-space: pre-wrap;
   margin-bottom: 0;
   font-size: 0.9em !important;
+  border-radius: var(--bs-border-radius);
 }
 
-._textCode_1wvgr_18 {
+._textCode_h7uyp_19 {
   word-wrap: anywhere;
+  color: inherit;
 }
 ._toolCallView_l6wae_1 {
   display: grid;
@@ -17700,44 +17702,44 @@ button._segment_mhb7y_9 {
   font-weight: 600;
   padding-bottom: 0.3em;
 }
-._container_1hidt_1 {
-  margin: 0.5em 0 0 0;
+._container_1gr6b_1 {
+  margin: 0;
   width: 100%;
 }
 
-._all_1hidt_6 {
+._all_1gr6b_6 {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   column-gap: 1em;
 }
 
-._tableSelection_1hidt_12 {
+._tableSelection_1gr6b_12 {
   width: fit-content;
   align-self: start;
   justify-self: start;
 }
 
-._tools_1hidt_18 {
+._tools_1gr6b_18 {
   grid-column: -1/1;
 }
 
-._codePre_1hidt_22 {
+._codePre_1gr6b_22 {
   background: var(--bs-light);
   width: 100%;
   padding: 0.5em;
   border-radius: var(--bs-border-radius);
 }
 
-._code_1hidt_22 {
+._code_1gr6b_22 {
   white-space: pre-wrap !important;
   word-wrap: anywhere !important;
 }
 
-._progress_1hidt_34 {
+._progress_1gr6b_34 {
   margin-left: 0.5em;
 }
 
-._error_1hidt_38 {
+._error_1gr6b_38 {
   display: flex;
   align-items: flex-start;
   gap: 0.5em;
@@ -17747,13 +17749,13 @@ button._segment_mhb7y_9 {
   border-radius: var(--bs-border-radius);
 }
 
-._error_1hidt_38 > i {
+._error_1gr6b_38 > i {
   color: var(--bs-danger);
   font-size: var(--inspect-font-size-smallest);
   line-height: normal;
 }
 
-._toolConfig_1hidt_54 {
+._toolConfig_1gr6b_54 {
   display: grid;
   grid-template-columns: max-content auto;
   column-gap: 1em;
@@ -17761,7 +17763,7 @@ button._segment_mhb7y_9 {
   padding-top: 0.5em;
 }
 
-._toolChoice_1hidt_62 {
+._toolChoice_1gr6b_62 {
   border-top: solid var(--bs-light-border-subtle) 1px;
   display: grid;
   grid-template-columns: max-content auto;
@@ -17770,7 +17772,7 @@ button._segment_mhb7y_9 {
   padding-top: 0.5em;
 }
 
-._traceback_1hidt_71 {
+._traceback_1gr6b_71 {
   margin-left: 1.5em;
   font-size: 0.85em;
   background: var(--bs-light);

--- a/src/inspect_ai/_view/www/dist/assets/index.css
+++ b/src/inspect_ai/_view/www/dist/assets/index.css
@@ -17157,22 +17157,22 @@ button._segment_mhb7y_9 {
   width: 100%;
   margin-top: 1em;
 }
-._tabPanel_6o9gh_1 {
+._tabPanel_20s9q_1 {
   padding-bottom: 1em;
 }
 
-._tabControls_6o9gh_5 {
+._tabControls_20s9q_5 {
   position: sticky;
   z-index: 1001;
   top: 0;
   background-color: var(--bs-body-bg);
 }
 
-._fullWidth_6o9gh_12 {
+._fullWidth_20s9q_12 {
   width: 100%;
 }
 
-._metadataPanel_6o9gh_16 {
+._metadataPanel_20s9q_16 {
   display: flex;
   flex-wrap: wrap;
   align-items: stretch;
@@ -17181,24 +17181,24 @@ button._segment_mhb7y_9 {
   margin-top: 0.5em;
 }
 
-._padded_6o9gh_25 {
+._padded_20s9q_25 {
   padding-left: 0.8em;
   margin-top: 0.4em;
 }
 
-._error_6o9gh_30 {
+._error_20s9q_30 {
   padding-top: 0.5em;
 }
 
-._ansi_6o9gh_34 {
+._ansi_20s9q_34 {
   margin: 1em 0;
 }
 
-._noTop_6o9gh_38 {
+._noTop_20s9q_38 {
   margin-top: 0;
 }
 
-._timePanel_6o9gh_42 {
+._timePanel_20s9q_42 {
   display: grid;
   grid-template-columns: max-content max-content;
   grid-template-rows: auto;
@@ -17206,16 +17206,20 @@ button._segment_mhb7y_9 {
   min-width: 200px;
 }
 
-._chat_6o9gh_50 {
+._chat_20s9q_50 {
   padding: 1em;
 }
 
-._padded_6o9gh_25 {
+._padded_20s9q_25 {
   padding: 1em;
 }
 
-._transcriptContainer_6o9gh_58 {
+._transcriptContainer_20s9q_58 {
   padding-bottom: 1em;
+}
+
+._overflowVisible_20s9q_62 {
+  overflow-y: visible;
 }
 ._body_x9ww7_1 {
   color: var(--bs-danger);

--- a/src/inspect_ai/_view/www/src/app/log-list/grid/LogListGrid.tsx
+++ b/src/inspect_ai/_view/www/src/app/log-list/grid/LogListGrid.tsx
@@ -7,9 +7,19 @@ import type {
 import { themeBalham } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import clsx from "clsx";
-import { FC, RefObject, useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  FC,
+  KeyboardEvent as ReactKeyboardEvent,
+  RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useNavigate } from "react-router-dom";
 
+import { FindBandUI } from "../../../components/FindBandUI";
 import { useLogs, useLogsListing } from "../../../state/hooks";
 import { useStore } from "../../../state/store";
 import "../../shared/agGrid";
@@ -51,6 +61,21 @@ export const LogListGrid: FC<LogListGridProps> = ({
   const internalGridRef = useRef<AgGridReact<LogListRow>>(null);
   const gridRef = externalGridRef ?? internalGridRef;
   const gridContainerRef = useRef<HTMLDivElement>(null);
+
+  // Find functionality state - store row IDs instead of IRowNode references to avoid memory leaks
+  const [showFind, setShowFind] = useState(false);
+  const [findTerm, setFindTerm] = useState("");
+  const [matchIds, setMatchIds] = useState<string[]>([]);
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+  const findInputRef = useRef<HTMLInputElement>(null);
+
+  // Helper to close find bar and reset state
+  const closeFind = useCallback(() => {
+    setShowFind(false);
+    setFindTerm("");
+    setMatchIds([]);
+    setCurrentMatchIndex(0);
+  }, []);
 
   const logFiles = useMemo(() => {
     return items
@@ -123,6 +148,12 @@ export const LogListGrid: FC<LogListGridProps> = ({
           }
         }
       }
+
+      // Pre-compute searchable text for fast Cmd+F search
+      row.searchText = [row.name, row.task, row.model, row.id]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
 
       return row;
     });
@@ -231,8 +262,111 @@ export const LogListGrid: FC<LogListGridProps> = ({
     resizeGridColumns();
   }, [columns, resizeGridColumns]);
 
+  // Find functionality - uses pre-computed searchText for O(1) lookup per row
+  const performSearch = useCallback(
+    (term: string) => {
+      const api = gridRef.current?.api;
+      if (!api || !term) {
+        setMatchIds([]);
+        setCurrentMatchIndex(0);
+        return;
+      }
+      const lowerTerm = term.toLowerCase();
+      const foundIds: string[] = [];
+      api.forEachNode((node) => {
+        const rowData = node.data;
+        if (!rowData?.searchText) return;
+        if (rowData.searchText.includes(lowerTerm)) {
+          foundIds.push(rowData.id);
+        }
+      });
+      setMatchIds(foundIds);
+      setCurrentMatchIndex(0);
+      if (foundIds.length > 0) {
+        const firstNode = api.getRowNode(foundIds[0]);
+        if (firstNode) {
+          api.deselectAll();
+          api.ensureNodeVisible(firstNode, "middle");
+          firstNode.setSelected(true, true);
+        }
+      }
+    },
+    [gridRef],
+  );
+
+  const goToMatch = useCallback(
+    (index: number) => {
+      if (matchIds.length === 0) return;
+      const idx =
+        ((index % matchIds.length) + matchIds.length) % matchIds.length;
+      setCurrentMatchIndex(idx);
+      const api = gridRef.current?.api;
+      if (!api) return;
+      const node = api.getRowNode(matchIds[idx]);
+      if (node) {
+        api.deselectAll();
+        api.ensureNodeVisible(node, "middle");
+        node.setSelected(true, true);
+      }
+    },
+    [matchIds, gridRef],
+  );
+
+  const handleInputKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Escape") {
+        closeFind();
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        goToMatch(currentMatchIndex + (e.shiftKey ? -1 : 1));
+      }
+    },
+    [goToMatch, currentMatchIndex, closeFind],
+  );
+
+  useEffect(() => {
+    const handleFindKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "f") {
+        e.preventDefault();
+        e.stopPropagation();
+        setShowFind(true);
+        setTimeout(() => findInputRef.current?.focus(), 100);
+      }
+      if (e.key === "Escape" && showFind) {
+        closeFind();
+      }
+    };
+    document.addEventListener("keydown", handleFindKeyDown, true);
+    return () =>
+      document.removeEventListener("keydown", handleFindKeyDown, true);
+  }, [closeFind, showFind]);
+
+  useEffect(() => {
+    if (findTerm) {
+      performSearch(findTerm);
+    } else {
+      setMatchIds([]);
+      setCurrentMatchIndex(0);
+    }
+  }, [findTerm, performSearch]);
+
   return (
     <div className={clsx(styles.gridWrapper)}>
+      {showFind && (
+        <FindBandUI
+          inputRef={findInputRef}
+          value={findTerm}
+          onChange={() => setFindTerm(findInputRef.current?.value ?? "")}
+          onKeyDown={handleInputKeyDown}
+          onClose={closeFind}
+          onPrevious={() => goToMatch(currentMatchIndex - 1)}
+          onNext={() => goToMatch(currentMatchIndex + 1)}
+          disableNav={matchIds.length === 0}
+          noResults={!!findTerm && matchIds.length === 0}
+          matchCount={findTerm ? matchIds.length : undefined}
+          matchIndex={findTerm ? currentMatchIndex : undefined}
+        />
+      )}
       <div ref={gridContainerRef} className={styles.gridContainer} tabIndex={0}>
         <AgGridReact<LogListRow>
           ref={gridRef}

--- a/src/inspect_ai/_view/www/src/app/log-list/grid/columns/types.ts
+++ b/src/inspect_ai/_view/www/src/app/log-list/grid/columns/types.ts
@@ -13,5 +13,6 @@ export interface LogListRow {
   completedAt?: string;
   itemCount?: number;
   log?: LogHandle;
+  searchText?: string; // Pre-computed searchable text for fast Cmd+F search
   [key: string]: any; // For dynamic score columns
 }

--- a/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.module.css
+++ b/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.module.css
@@ -58,3 +58,7 @@
 .transcriptContainer {
   padding-bottom: 1em;
 }
+
+.overflowVisible {
+  overflow-y: visible;
+}

--- a/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.tsx
@@ -78,6 +78,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
   const sample = useMemo(() => {
     return sampleData.getSelectedSample();
   }, [sampleData]);
+  const eventsCleared = sampleData.eventsCleared;
 
   const runningSampleData = sampleData.running;
 
@@ -363,10 +364,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
             key={`${baseId}-transcript-display-${id}`}
             id={`${baseId}-transcript-display-${id}`}
             events={sampleEvents || []}
-            eventsCleared={
-              (sample as Record<string, unknown> | undefined)
-                ?._events_cleared === true
-            }
+            eventsCleared={eventsCleared}
             initialEventId={sampleDetailNavigation.event}
             topOffset={tabsHeight}
             running={running}

--- a/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.tsx
@@ -340,7 +340,11 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
         <TabPanel
           key={kSampleTranscriptTabId}
           id={kSampleTranscriptTabId}
-          className={clsx("sample-tab", styles.transcriptContainer)}
+          className={clsx(
+            "sample-tab",
+            styles.transcriptContainer,
+            styles.overflowVisible,
+          )}
           title="Transcript"
           onSelected={onSelectedTab}
           selected={
@@ -368,7 +372,12 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
         <TabPanel
           key={kSampleMessagesTabId}
           id={kSampleMessagesTabId}
-          className={clsx("sample-tab", styles.fullWidth, styles.chat)}
+          className={clsx(
+            "sample-tab",
+            styles.fullWidth,
+            styles.chat,
+            styles.overflowVisible,
+          )}
           title="Messages"
           onSelected={onSelectedTab}
           selected={effectiveSelectedTab === kSampleMessagesTabId}

--- a/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.tsx
@@ -363,6 +363,10 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
             key={`${baseId}-transcript-display-${id}`}
             id={`${baseId}-transcript-display-${id}`}
             events={sampleEvents || []}
+            eventsCleared={
+              (sample as Record<string, unknown> | undefined)
+                ?._events_cleared === true
+            }
             initialEventId={sampleDetailNavigation.event}
             topOffset={tabsHeight}
             running={running}

--- a/src/inspect_ai/_view/www/src/app/samples/chat/ChatMessage.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/chat/ChatMessage.tsx
@@ -24,6 +24,7 @@ interface ChatMessageProps {
   indented?: boolean;
   toolCallStyle: ChatViewToolCallStyle;
   allowLinking?: boolean;
+  unlabeledRoles?: string[];
 }
 
 export const ChatMessage: FC<ChatMessageProps> = memo(
@@ -34,12 +35,27 @@ export const ChatMessage: FC<ChatMessageProps> = memo(
     indented,
     toolCallStyle,
     allowLinking = true,
+    unlabeledRoles,
   }) => {
     const messageUrl = useSampleMessageUrl(message.id);
+    const [mouseOver, setMouseOver] = useState(false);
 
     const collapse = message.role === "system" || message.role === "user";
+    const hideRole = unlabeledRoles?.includes(message.role) ?? false;
 
-    const [mouseOver, setMouseOver] = useState(false);
+    // When the role header is hidden, skip rendering if there's no visible
+    // text content (e.g. assistant messages with only tool_calls).
+    if (hideRole) {
+      const content = message.content;
+      const hasVisibleContent =
+        typeof content === "string"
+          ? content.trim().length > 0
+          : Array.isArray(content) &&
+            content.some((c) => c.type !== "tool_use");
+      if (!hasVisibleContent) {
+        return null;
+      }
+    }
 
     return (
       <div
@@ -54,32 +70,34 @@ export const ChatMessage: FC<ChatMessageProps> = memo(
         onMouseEnter={() => setMouseOver(true)}
         onMouseLeave={() => setMouseOver(false)}
       >
-        <div
-          className={clsx(
-            styles.messageGrid,
-            message.role === "tool" ? styles.toolMessageGrid : undefined,
-            "text-style-label",
-          )}
-        >
-          <div>
-            {message.role}
-            {message.role === "tool" ? `: ${message.function}` : ""}
-            {supportsLinking() && messageUrl && allowLinking ? (
-              <CopyButton
-                icon={ApplicationIcons.link}
-                value={toFullUrl(messageUrl)}
-                className={clsx(styles.copyLink)}
-              />
-            ) : (
-              ""
+        {!hideRole && (
+          <div
+            className={clsx(
+              styles.messageGrid,
+              message.role === "tool" ? styles.toolMessageGrid : undefined,
+              "text-style-label",
+            )}
+          >
+            <div>
+              {message.role}
+              {message.role === "tool" ? `: ${message.function}` : ""}
+              {supportsLinking() && messageUrl && allowLinking ? (
+                <CopyButton
+                  icon={ApplicationIcons.link}
+                  value={toFullUrl(messageUrl)}
+                  className={clsx(styles.copyLink)}
+                />
+              ) : (
+                ""
+              )}
+            </div>
+            {message.timestamp && (
+              <span className={styles.timestamp} title={message.timestamp}>
+                {formatDateTime(new Date(message.timestamp))}
+              </span>
             )}
           </div>
-          {message.timestamp && (
-            <span className={styles.timestamp} title={message.timestamp}>
-              {formatDateTime(new Date(message.timestamp))}
-            </span>
-          )}
-        </div>
+        )}
         <div
           className={clsx(
             styles.messageContents,

--- a/src/inspect_ai/_view/www/src/app/samples/chat/ChatMessageRow.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/chat/ChatMessageRow.tsx
@@ -15,6 +15,7 @@ interface ChatMessageRowProps {
   padded?: boolean;
   highlightUserMessage?: boolean;
   allowLinking?: boolean;
+  unlabeledRoles?: string[];
 }
 
 /**
@@ -28,6 +29,7 @@ export const ChatMessageRow: FC<ChatMessageRowProps> = ({
   indented,
   highlightUserMessage,
   allowLinking = true,
+  unlabeledRoles,
 }) => {
   if (number) {
     return (
@@ -57,6 +59,7 @@ export const ChatMessageRow: FC<ChatMessageRowProps> = ({
             indented={indented}
             toolCallStyle={toolCallStyle}
             allowLinking={allowLinking}
+            unlabeledRoles={unlabeledRoles}
           />
         </div>
       </>
@@ -79,6 +82,7 @@ export const ChatMessageRow: FC<ChatMessageRowProps> = ({
           indented={indented}
           toolCallStyle={toolCallStyle}
           allowLinking={allowLinking}
+          unlabeledRoles={unlabeledRoles}
         />
         {resolvedMessage.message.role === "user" ? (
           <div style={{ height: "10px" }}></div>

--- a/src/inspect_ai/_view/www/src/app/samples/chat/ChatView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/chat/ChatView.tsx
@@ -15,6 +15,7 @@ interface ChatViewProps {
   numbered?: boolean;
   className?: string | string[];
   allowLinking?: boolean;
+  unlabeledRoles?: string[];
 }
 
 /**
@@ -29,6 +30,7 @@ export const ChatView: FC<ChatViewProps> = ({
   numbered = true,
   className,
   allowLinking = true,
+  unlabeledRoles,
 }) => {
   const collapsedMessages = resolveToolCallsIntoPreviousMessage
     ? resolveMessages(messages)
@@ -53,6 +55,7 @@ export const ChatView: FC<ChatViewProps> = ({
             toolCallStyle={toolCallStyle}
             allowLinking={allowLinking}
             highlightUserMessage={true}
+            unlabeledRoles={unlabeledRoles}
           />
         );
       })}

--- a/src/inspect_ai/_view/www/src/app/samples/chat/tools/ToolOutput.module.css
+++ b/src/inspect_ai/_view/www/src/app/samples/chat/tools/ToolOutput.module.css
@@ -13,8 +13,10 @@
   white-space: pre-wrap;
   margin-bottom: 0;
   font-size: 0.9em !important;
+  border-radius: var(--bs-border-radius);
 }
 
 .textCode {
   word-wrap: anywhere;
+  color: inherit;
 }

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/ModelEventView.module.css
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/ModelEventView.module.css
@@ -1,5 +1,5 @@
 .container {
-  margin: 0.5em 0 0 0;
+  margin: 0;
   width: 100%;
 }
 

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/ModelEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/ModelEventView.tsx
@@ -15,6 +15,7 @@ import { EventSection } from "./event/EventSection";
 import { ANSIDisplay } from "../../../components/AnsiDisplay";
 import { PulsingDots } from "../../../components/PulsingDots";
 import { usePrismHighlight } from "../../../components/prism";
+import { formatDateTime } from "../../../utils/format";
 import { Message } from "../chat/messages";
 import styles from "./ModelEventView.module.css";
 import { EventNodeContext } from "./TranscriptVirtualList";
@@ -91,16 +92,26 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
 
   const panelTitle = eventTitle(event);
 
-  const turnLabel = context?.turnInfo
+  const outputRole =
+    outputMessages.length > 0 ? outputMessages[0].role : undefined;
+
+  const outputTimestamp = event.completed
+    ? formatDateTime(new Date(event.completed))
+    : undefined;
+
+  const baseTurnLabel = context?.turnInfo
     ? `turn ${context.turnInfo.turnNumber}/${context.turnInfo.totalTurns}`
     : undefined;
+
+  const turnLabel =
+    [outputTimestamp, baseTurnLabel].filter(Boolean).join(" | ") || undefined;
 
   return (
     <EventPanel
       eventNodeId={eventNode.id}
       depth={eventNode.depth}
-      className={className}
-      title={formatTitle(panelTitle, totalUsage, callTime)}
+      className={clsx(className)}
+      title={formatTitle(panelTitle, totalUsage, callTime, outputRole)}
       subTitle={formatTiming(event.timestamp, event.working_start)}
       icon={ApplicationIcons.model}
       turnLabel={turnLabel}
@@ -113,6 +124,7 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
           toolCallStyle={showToolCalls ? "complete" : "omit"}
           resolveToolCallsIntoPreviousMessage={context?.hasToolEvents !== false}
           allowLinking={false}
+          unlabeledRoles={["assistant"]}
         />
         {event.error ? (
           <div className={styles.error}>

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/TranscriptPanel.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/TranscriptPanel.tsx
@@ -33,13 +33,22 @@ interface TranscriptPanelProps {
   running?: boolean;
   initialEventId?: string | null;
   topOffset?: number;
+  eventsCleared?: boolean;
 }
 
 /**
  * Renders the Transcript Virtual List.
  */
 export const TranscriptPanel: FC<TranscriptPanelProps> = memo((props) => {
-  let { id, scrollRef, events, running, initialEventId, topOffset } = props;
+  let {
+    id,
+    scrollRef,
+    events,
+    running,
+    initialEventId,
+    topOffset,
+    eventsCleared,
+  } = props;
 
   // Sort out any types that are filtered out
   const filteredEventTypes = useStore(
@@ -255,7 +264,9 @@ export const TranscriptPanel: FC<TranscriptPanelProps> = memo((props) => {
       flattenedNodes.length === 0 && events.length > 0;
     const message = isCompletedFiltered
       ? "The currently applied filter hides all events."
-      : "No events to display.";
+      : eventsCleared
+        ? "Transcript events were removed because this sample exceeds the browser's size limit. Use the Messages tab to view the conversation."
+        : "No events to display.";
     return <NoContentsPanel text={message} />;
   } else {
     return (

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/event/utils.ts
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/event/utils.ts
@@ -96,7 +96,9 @@ export const formatTitle = (
   title: string,
   total_tokens?: number,
   working_start?: number | null,
+  role?: string,
 ) => {
+  const titleWithRole = role ? `${title} – ${role} –` : title;
   const subItems = [];
   if (total_tokens) {
     subItems.push(`${formatNumber(total_tokens)} tokens`);
@@ -105,5 +107,5 @@ export const formatTitle = (
     subItems.push(`${formatTime(working_start)}`);
   }
   const subtitle = subItems.length > 0 ? ` (${subItems.join(", ")})` : "";
-  return `${title}${subtitle}`;
+  return `${titleWithRole}${subtitle}`;
 };

--- a/src/inspect_ai/_view/www/src/app/types.ts
+++ b/src/inspect_ai/_view/www/src/app/types.ts
@@ -144,6 +144,7 @@ export interface SampleState {
   sampleError: Error | undefined;
   sampleNeedsReload: number;
   downloadProgress?: DownloadProgress;
+  eventsCleared: boolean;
 
   visiblePopover?: string;
 

--- a/src/inspect_ai/_view/www/src/components/FindBand.css
+++ b/src/inspect_ai/_view/www/src/components/FindBand.css
@@ -45,11 +45,15 @@
 .findBand .btn.next,
 .findBand .btn.prev {
   padding: 0;
+  border: none;
+  background: none;
   font-size: var(--inspect-fond-size-larger);
 }
 
 .findBand .btn.close {
   padding: 0;
+  border: none;
+  background: none;
   font-size: var(--inspect-font-size-title-secondary);
   margin-top: -0.1rem;
   margin-bottom: -0.1rem;

--- a/src/inspect_ai/_view/www/src/components/FindBand.tsx
+++ b/src/inspect_ai/_view/www/src/components/FindBand.tsx
@@ -1,4 +1,3 @@
-import clsx from "clsx";
 import {
   FC,
   KeyboardEvent,
@@ -8,12 +7,11 @@ import {
   useRef,
   useState,
 } from "react";
-import { ApplicationIcons } from "../app/appearance/icons";
 import { useStore } from "../state/store";
 import { findScrollableParent, scrollRangeToCenter } from "../utils/dom";
 import { debounce } from "../utils/sync";
 import { useExtendedFind } from "./ExtendedFindContext";
-import "./FindBand.css";
+import { FindBandUI } from "./FindBandUI";
 
 interface FindBandProps {}
 
@@ -334,57 +332,23 @@ export const FindBand: FC<FindBandProps> = () => {
     };
   }, [handleSearch, restoreCursor]);
 
-  const matchCountLabel = useMemo(() => {
-    if (matchCount === null) return null;
-    if (matchCount === 0) return "No results";
-    return `${currentMatchIndex} of ${matchCount}`;
-  }, [matchCount, currentMatchIndex]);
-
   return (
-    <div data-unsearchable="true" className={clsx("findBand")}>
-      <input
-        type="text"
-        ref={searchBoxRef}
-        placeholder="Find"
-        onKeyDown={handleKeyDown}
-        onBeforeInput={handleBeforeInput}
-        onChange={handleInputChange}
-      />
-      {matchCountLabel !== null && (
-        <span
-          className={clsx(
-            "findBand-match-count",
-            matchCount === 0 && "findBand-no-results",
-          )}
-        >
-          {matchCountLabel}
-        </span>
-      )}
-      <button
-        type="button"
-        title="Previous match"
-        className="btn next"
-        onClick={findPrevious}
-      >
-        <i className={ApplicationIcons.arrows.up} />
-      </button>
-      <button
-        type="button"
-        title="Next match"
-        className="btn prev"
-        onClick={findNext}
-      >
-        <i className={ApplicationIcons.arrows.down} />
-      </button>
-      <button
-        type="button"
-        title="Close"
-        className="btn close"
-        onClick={storeHideFind}
-      >
-        <i className={ApplicationIcons.close} />
-      </button>
-    </div>
+    <FindBandUI
+      inputRef={searchBoxRef}
+      onClose={storeHideFind}
+      onNext={findNext}
+      onPrevious={findPrevious}
+      onKeyDown={handleKeyDown}
+      onBeforeInput={handleBeforeInput}
+      onChange={handleInputChange}
+      noResults={matchCount !== null && matchCount === 0}
+      matchCount={matchCount ?? undefined}
+      matchIndex={
+        matchCount !== null && matchCount > 0
+          ? currentMatchIndex - 1
+          : undefined
+      }
+    />
   );
 };
 function windowFind(searchTerm: string, back: boolean): boolean {

--- a/src/inspect_ai/_view/www/src/components/FindBandUI.tsx
+++ b/src/inspect_ai/_view/www/src/components/FindBandUI.tsx
@@ -1,0 +1,97 @@
+import clsx from "clsx";
+import React, { FC, KeyboardEvent, RefObject, useRef } from "react";
+import { ApplicationIcons } from "../app/appearance/icons";
+import "./FindBand.css";
+
+interface FindBandUIProps {
+  onClose: () => void;
+  onNext: () => void;
+  onPrevious: () => void;
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
+  onChange?: () => void;
+  onBeforeInput?: () => void;
+  value?: string;
+  matchCount?: number;
+  matchIndex?: number;
+  noResults?: boolean;
+  disableNav?: boolean;
+  inputRef?: RefObject<HTMLInputElement | null>;
+}
+
+export const FindBandUI: FC<FindBandUIProps> = ({
+  onClose,
+  onNext,
+  onPrevious,
+  onKeyDown,
+  onChange,
+  onBeforeInput,
+  value,
+  matchCount,
+  matchIndex,
+  noResults = false,
+  disableNav,
+  inputRef: externalRef,
+}) => {
+  const internalRef = useRef<HTMLInputElement>(null);
+  const inputRef = externalRef ?? internalRef;
+
+  // Build input props — only include `value` when controlled
+  const inputProps: React.InputHTMLAttributes<HTMLInputElement> = {
+    type: "text",
+    placeholder: "Find",
+    onKeyDown,
+    onBeforeInput,
+    onChange,
+  };
+  if (value !== undefined) {
+    inputProps.value = value;
+  }
+
+  const hasCount = matchCount !== undefined && matchIndex !== undefined;
+  const showStatus = noResults || (hasCount && matchCount > 0);
+  const statusText =
+    hasCount && matchCount > 0
+      ? `${matchIndex + 1} of ${matchCount}`
+      : "No results";
+
+  return (
+    <div data-unsearchable="true" className={clsx("findBand")}>
+      <input ref={inputRef} {...inputProps} />
+      <span
+        className={clsx(
+          "findBand-match-count",
+          noResults && matchCount === 0 && "findBand-no-results",
+        )}
+        style={{ visibility: showStatus ? "visible" : "hidden" }}
+      >
+        {statusText}
+      </span>
+      <button
+        type="button"
+        title="Previous match"
+        className="btn prev"
+        onClick={onPrevious}
+        disabled={disableNav}
+      >
+        <i className={ApplicationIcons.arrows.up} />
+      </button>
+      <button
+        type="button"
+        title="Next match"
+        className="btn next"
+        onClick={onNext}
+        disabled={disableNav}
+      >
+        <i className={ApplicationIcons.arrows.down} />
+      </button>
+      <button
+        type="button"
+        title="Close"
+        className="btn close"
+        onClick={onClose}
+      >
+        <i className={ApplicationIcons.close} />
+      </button>
+    </div>
+  );
+};

--- a/src/inspect_ai/_view/www/src/state/hooks.ts
+++ b/src/inspect_ai/_view/www/src/state/hooks.ts
@@ -247,6 +247,7 @@ export const useSampleData = () => {
     (state) => state.sample.sample_identifier,
   );
   const sampleNeedsReload = useStore((state) => state.sample.sampleNeedsReload);
+  const eventsCleared = useStore((state) => state.sample.eventsCleared);
   const runningEvents = useStore(
     (state) => state.sample.runningEvents,
   ) as Events;
@@ -258,6 +259,7 @@ export const useSampleData = () => {
       sampleNeedsReload,
       error: sampleError,
       getSelectedSample,
+      eventsCleared,
       running: runningEvents,
       downloadProgress,
     };
@@ -267,6 +269,7 @@ export const useSampleData = () => {
     getSelectedSample,
     selectedSampleIdentifier,
     sampleNeedsReload,
+    eventsCleared,
     runningEvents,
     downloadProgress,
   ]);

--- a/src/inspect_ai/_view/www/src/state/sampleSlice.ts
+++ b/src/inspect_ai/_view/www/src/state/sampleSlice.ts
@@ -93,6 +93,7 @@ const initialState: SampleState = {
   sampleStatus: "ok",
   sampleError: undefined,
   downloadProgress: undefined,
+  eventsCleared: false,
 
   visiblePopover: undefined,
 
@@ -124,6 +125,12 @@ export const createSampleSlice = (
       setSelectedSample: (sample: EvalSample, logFile: string) => {
         const isLarge = isLargeSample(sample);
 
+        // Detect if events were cleared by the preprocessor:
+        // a sample with messages but no events indicates the events array
+        // was stripped to reduce memory usage.
+        const eventsCleared =
+          sample.events.length === 0 && (sample.messages?.length ?? 0) > 0;
+
         // Update state based on sample size
         set((state) => {
           state.sample.sample_identifier = {
@@ -132,6 +139,7 @@ export const createSampleSlice = (
             logFile: logFile,
           };
           state.sample.sampleInState = !isLarge;
+          state.sample.eventsCleared = eventsCleared;
 
           // Only store in state if it's small
           if (!isLarge) {

--- a/src/inspect_ai/_view/www/src/tests/utils/clear-events-preprocessor.test.ts
+++ b/src/inspect_ai/_view/www/src/tests/utils/clear-events-preprocessor.test.ts
@@ -1,0 +1,69 @@
+import { TextEncoder, TextDecoder } from "util";
+
+import { clearLargeEventsArray } from "../../utils/clear-events-preprocessor";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder() as InstanceType<
+  typeof globalThis.TextDecoder
+>;
+
+function encode(str: string): Uint8Array {
+  return encoder.encode(str);
+}
+
+function decode(data: Uint8Array): string {
+  return decoder.decode(data);
+}
+
+describe("clearLargeEventsArray", () => {
+  it("returns data unchanged when total size is under the limit", () => {
+    const json = '{"events": [1,2,3], "other": "data"}';
+    const data = encode(json);
+    const result = clearLargeEventsArray(data);
+    expect(decode(result)).toBe(json);
+  });
+
+  it("clears events and adds _events_cleared marker when events exceed limit", () => {
+    // Create a JSON with events larger than MAX_EVENTS_SIZE_BYTES (350MB)
+    // We'll test with a smaller threshold by creating data > 350MB
+    // Instead, test the byte-level logic with a mock that's > threshold
+    // The function checks data.length first, so we need data > 350MB to proceed
+    // For unit testing, we'll test the marker insertion logic directly
+
+    // Create a large enough payload to trigger clearing
+    // MAX_EVENTS_SIZE_BYTES = 350 * 1024 * 1024, MAX_TOTAL_SIZE = 512 * 1024 * 1024
+    // The early exit is: if (data.length <= MAX_EVENTS_SIZE_BYTES) return data
+    // So we need data > 350MB to even check events
+
+    // Since creating 350MB+ buffers in tests is impractical, we test the marker
+    // insertion logic by verifying the output format with a helper
+    const json = '{"id":"test","events":[{"event":"model"}],"scores":{}}';
+    const data = encode(json);
+    // This won't trigger clearing since data is small
+    const result = clearLargeEventsArray(data);
+    expect(decode(result)).toBe(json);
+  });
+
+  it("preserves valid JSON structure when events are at different positions", () => {
+    // Events as last property
+    const json1 = '{"id":"test","scores":{},"events":[1,2,3]}';
+    const data1 = encode(json1);
+    expect(decode(clearLargeEventsArray(data1))).toBe(json1);
+
+    // Events as first property
+    const json2 = '{"events":[1,2,3],"id":"test"}';
+    const data2 = encode(json2);
+    expect(decode(clearLargeEventsArray(data2))).toBe(json2);
+
+    // Events as middle property
+    const json3 = '{"id":"test","events":[1,2,3],"scores":{}}';
+    const data3 = encode(json3);
+    expect(decode(clearLargeEventsArray(data3))).toBe(json3);
+  });
+
+  it("handles JSON with no events property", () => {
+    const json = '{"id":"test","scores":{}}';
+    const data = encode(json);
+    expect(decode(clearLargeEventsArray(data))).toBe(json);
+  });
+});

--- a/src/inspect_ai/_view/www/src/tests/utils/clear-events-preprocessor.test.ts
+++ b/src/inspect_ai/_view/www/src/tests/utils/clear-events-preprocessor.test.ts
@@ -23,23 +23,9 @@ describe("clearLargeEventsArray", () => {
     expect(decode(result)).toBe(json);
   });
 
-  it("clears events and adds _events_cleared marker when events exceed limit", () => {
-    // Create a JSON with events larger than MAX_EVENTS_SIZE_BYTES (350MB)
-    // We'll test with a smaller threshold by creating data > 350MB
-    // Instead, test the byte-level logic with a mock that's > threshold
-    // The function checks data.length first, so we need data > 350MB to proceed
-    // For unit testing, we'll test the marker insertion logic directly
-
-    // Create a large enough payload to trigger clearing
-    // MAX_EVENTS_SIZE_BYTES = 350 * 1024 * 1024, MAX_TOTAL_SIZE = 512 * 1024 * 1024
-    // The early exit is: if (data.length <= MAX_EVENTS_SIZE_BYTES) return data
-    // So we need data > 350MB to even check events
-
-    // Since creating 350MB+ buffers in tests is impractical, we test the marker
-    // insertion logic by verifying the output format with a helper
+  it("returns data unchanged for small payloads even with events", () => {
     const json = '{"id":"test","events":[{"event":"model"}],"scores":{}}';
     const data = encode(json);
-    // This won't trigger clearing since data is small
     const result = clearLargeEventsArray(data);
     expect(decode(result)).toBe(json);
   });

--- a/src/inspect_ai/_view/www/src/utils/clear-events-preprocessor.ts
+++ b/src/inspect_ai/_view/www/src/utils/clear-events-preprocessor.ts
@@ -117,8 +117,9 @@ function findArrayEnd(data: Uint8Array, arrayStart: number): number {
 }
 
 /**
- * Clears events array at the byte level if it exceeds 100MB.
- * Replaces the entire events array with an empty array.
+ * Clears events array at the byte level if it exceeds the size limits.
+ * Replaces the entire events array with an empty array and adds an
+ * "_events_cleared" marker to the JSON so the UI can show a helpful message.
  * This allows handling gigabyte-sized files without running out of memory.
  */
 export function clearLargeEventsArray(data: Uint8Array): Uint8Array {
@@ -142,17 +143,24 @@ export function clearLargeEventsArray(data: Uint8Array): Uint8Array {
     return data;
   }
 
-  // Build result with empty events array: []
+  // Build result with empty events array [] and a marker property
   const before = data.slice(0, arrayStart + 1); // Up to and including [
-  const after = data.slice(arrayEnd); // From ] onwards
+  const closingBracket = data.slice(arrayEnd, arrayEnd + 1); // ]
+  const afterBracket = data.slice(arrayEnd + 1); // Everything after ]
+  const marker = new TextEncoder().encode(',"_events_cleared":true');
 
-  // Combine: before + ] + after (just close the bracket immediately)
-  const result = new Uint8Array(before.length + after.length);
+  const result = new Uint8Array(
+    before.length + closingBracket.length + marker.length + afterBracket.length,
+  );
 
   let offset = 0;
   result.set(before, offset);
   offset += before.length;
-  result.set(after, offset);
+  result.set(closingBracket, offset);
+  offset += closingBracket.length;
+  result.set(marker, offset);
+  offset += marker.length;
+  result.set(afterBracket, offset);
 
   return result;
 }

--- a/src/inspect_ai/_view/www/src/utils/clear-events-preprocessor.ts
+++ b/src/inspect_ai/_view/www/src/utils/clear-events-preprocessor.ts
@@ -118,8 +118,7 @@ function findArrayEnd(data: Uint8Array, arrayStart: number): number {
 
 /**
  * Clears events array at the byte level if it exceeds the size limits.
- * Replaces the entire events array with an empty array and adds an
- * "_events_cleared" marker to the JSON so the UI can show a helpful message.
+ * Replaces the entire events array with an empty array.
  * This allows handling gigabyte-sized files without running out of memory.
  */
 export function clearLargeEventsArray(data: Uint8Array): Uint8Array {
@@ -143,24 +142,16 @@ export function clearLargeEventsArray(data: Uint8Array): Uint8Array {
     return data;
   }
 
-  // Build result with empty events array [] and a marker property
+  // Build result with empty events array: []
   const before = data.slice(0, arrayStart + 1); // Up to and including [
-  const closingBracket = data.slice(arrayEnd, arrayEnd + 1); // ]
-  const afterBracket = data.slice(arrayEnd + 1); // Everything after ]
-  const marker = new TextEncoder().encode(',"_events_cleared":true');
+  const after = data.slice(arrayEnd); // From ] onwards
 
-  const result = new Uint8Array(
-    before.length + closingBracket.length + marker.length + afterBracket.length,
-  );
+  const result = new Uint8Array(before.length + after.length);
 
   let offset = 0;
   result.set(before, offset);
   offset += before.length;
-  result.set(closingBracket, offset);
-  offset += closingBracket.length;
-  result.set(marker, offset);
-  offset += marker.length;
-  result.set(afterBracket, offset);
+  result.set(after, offset);
 
   return result;
 }


### PR DESCRIPTION
## Summary

Cherry-picks several view improvements from upstream for the upcoming release:

**Cherry-picked PRs:**
- [#3338](https://github.com/UKGovernmentBEIS/inspect_ai/pull/3338) - Add Cmd+F search to LogListGrid (tasks list)
- [#3330](https://github.com/UKGovernmentBEIS/inspect_ai/pull/3330) - Improve transcript event styling
- [#3392](https://github.com/UKGovernmentBEIS/inspect_ai/pull/3392) - Fix scroll cutoff in virtual list sample tabs
- [#3395](https://github.com/UKGovernmentBEIS/inspect_ai/pull/3395) - [PLT-633] Show descriptive message when transcript events are cleared due to size

## Changes

### Cmd+F in Tasks Grid (#3338)
- Adds Cmd+F/Ctrl+F search functionality to the tasks grid (LogListGrid)
- Works with AG Grid's virtualized rows by searching through data directly
- Reuses FindBandUI component for consistent styling with transcript find

### Transcript Event Styling (#3330)
- Improved visual styling for transcript events

### Scroll Cutoff Fix (#3392)
- Fixes scroll cutoff issue in virtual list sample tabs

### Events Cleared Message (#3395)
- Shows descriptive message when transcript events are cleared due to size
- Typesafe detection of cleared events

## Testing

- [x] Dist files rebuilt from source
- [x] Source file conflicts resolved (combined faber's downloadProgress with eventsCleared)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)