### PR TITLE
Set oom_score_adj on exec_remote child processes

### DIFF
--- a/src/inspect_sandbox_tools/src/inspect_sandbox_tools/_remote_tools/_exec_remote/_job.py
+++ b/src/inspect_sandbox_tools/src/inspect_sandbox_tools/_remote_tools/_exec_remote/_job.py
@@ -62,6 +62,14 @@ class Job:
             cwd=cwd,
         )
 
+        # Make child (and its descendants via fork inheritance) the preferred
+        # OOM-kill target so the server process survives memory pressure.
+        try:
+            with open(f"/proc/{process.pid}/oom_score_adj", "w") as f:
+                f.write("1000")
+        except OSError:
+            pass
+
         job = cls(process, output_limit=output_limit)
 
         # Write initial input if provided


### PR DESCRIPTION
## Summary
- Cherry-pick of the oom_score_adj change onto the hotfix branch
- Sets `oom_score_adj` to 1000 on child processes spawned by `exec_remote()` so the OOM killer prefers them over the sandbox tools server
- Best-effort: silently ignored if `/proc` is unavailable
- No privileges required; inherited by grandchildren via `fork()`

## Test plan
- [ ] Verify `/proc/<pid>/oom_score_adj` reads `1000` for processes spawned via `exec_remote()` inside a container

🤖 Generated with [Claude Code](https://claude.com/claude-code)