### PR TITLE
cherry-pick: viewer middle-click support (upstream #3442)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Anthropic: Agent bridge now maps native bash tool to standard `bash()` tool.
 - Google: Update to `google-genai` v1.62.0 to fix issue with error handling in proxy configurations.
 - Hooks: Add eval context id fields to `ModelUsageData` hook.
+- Inspect View: Add middle-click support to open tasks and samples in a new browser tab.
 
 ## 0.3.196 (16 March 2026)
 

--- a/src/inspect_ai/_view/www/src/app/log-list/grid/LogListGrid.tsx
+++ b/src/inspect_ai/_view/www/src/app/log-list/grid/LogListGrid.tsx
@@ -1,4 +1,5 @@
 import type {
+  CellMouseDownEvent,
   GridColumnsChangedEvent,
   IRowNode,
   RowClickedEvent,
@@ -229,6 +230,17 @@ export const LogListGrid: FC<LogListGridProps> = ({
     };
   }, [handleKeyDown]);
 
+  const handleCellMouseDown = useCallback(
+    (e: CellMouseDownEvent<LogListRow>) => {
+      const mouseEvent = e.event as MouseEvent | undefined;
+      if (mouseEvent?.button === 1 && e.data?.url) {
+        mouseEvent.preventDefault();
+        window.open(`#${e.data.url}`, "_blank");
+      }
+    },
+    [],
+  );
+
   useEffect(() => {
     const loadHeaders = async () => {
       const filesToLoad = logFiles.filter((file) => !logPreviews[file.name]);
@@ -410,6 +422,7 @@ export const LogListGrid: FC<LogListGridProps> = ({
             }
           }}
           onRowClicked={handleRowClick}
+          onCellMouseDown={handleCellMouseDown}
           onSortChanged={handleSortChanged}
           onFilterChanged={handleFilterChanged}
           loading={data.length === 0 && (loading > 0 || syncing)}

--- a/src/inspect_ai/_view/www/src/app/samples-panel/samples-grid/SamplesGrid.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples-panel/samples-grid/SamplesGrid.tsx
@@ -1,4 +1,5 @@
 import type {
+  CellMouseDownEvent,
   ColDef,
   GridApi,
   GridColumnsChangedEvent,
@@ -64,7 +65,7 @@ export const SamplesGrid: FC<SamplesGridProps> = ({
   );
 
   const internalGridRef = useRef<AgGridReact<SampleRow>>(null);
-  const gridRef = externalGridRef || internalGridRef;
+  const gridRef = externalGridRef ?? internalGridRef;
   const gridContainerRef = useRef<HTMLDivElement>(null);
 
   // Polling for updated log files
@@ -154,7 +155,6 @@ export const SamplesGrid: FC<SamplesGridProps> = ({
     [gridRef, handleOpenRow],
   );
 
-  // Set up keyboard event listener
   useEffect(() => {
     const gridElement = gridContainerRef.current;
     if (!gridElement) return;
@@ -165,6 +165,22 @@ export const SamplesGrid: FC<SamplesGridProps> = ({
       gridElement.removeEventListener("keydown", handleKeyDown);
     };
   }, [handleKeyDown]);
+
+  const handleCellMouseDown = useCallback(
+    (e: CellMouseDownEvent<SampleRow>) => {
+      const mouseEvent = e.event as MouseEvent | undefined;
+      if (mouseEvent?.button === 1 && e.data) {
+        mouseEvent.preventDefault();
+        navigateToSampleDetail(
+          e.data.logFile,
+          e.data.sampleId,
+          e.data.epoch,
+          true,
+        );
+      }
+    },
+    [navigateToSampleDetail],
+  );
 
   const sampleRowId = (
     logFile: string,
@@ -257,6 +273,7 @@ export const SamplesGrid: FC<SamplesGridProps> = ({
             }
           }}
           onRowClicked={handleRowClick}
+          onCellMouseDown={handleCellMouseDown}
           onFilterChanged={() => {
             if (gridRef.current?.api) {
               const newDisplayedSamples = gridDisplayedSamples(


### PR DESCRIPTION
## Summary

Cherry-pick of [UKGovernmentBEIS/inspect_ai#3442](https://github.com/UKGovernmentBEIS/inspect_ai/pull/3442) (merged upstream `fd12f2c4`) into the `hotfix` branch.

Adds middle-click support to open tasks/samples in a new browser tab in the log viewer.

## Changes

- `onCellMouseDown` handler in `LogListGrid`, `SamplesGrid`, and `SampleList` for middle-click (`button === 1`)
- Opens clicked row in new tab via `window.open(url, "_blank")`
- CHANGELOG updated with upstream entries through 0.3.196

## Context

`METR/inspect-action` currently pins `inspect-ai` to commit `bb99d9f6` on this branch. Once merged, update the pin in inspect-action's `pyproject.toml` to include this feature.